### PR TITLE
Add OpenCV Confidence level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ log.html
 *-screenshot-*.png
 *\$py.class
 *.swp
+*__pycache__

--- a/README.rst
+++ b/README.rst
@@ -28,13 +28,10 @@ __ https://travis-ci.org/Eficode/robotframework-imagehorizonlibrary/
 Prerequisites
 -------------
 
-- `Python 2.7+`_ (unfortunately not 3.x)
+- `Python 2.7+`
 - pip_ for easy installation
 - pyautogui_ and `it's prerequisites`_
 - `Robot Framework`_
-
-On OS X, Retina display might `double all coordinates`_ from what they are
-suppose to be. Unfortunately you need to work around this problem yourself.
 
 On Ubuntu, you need to take `special measures`_ to make the screenshot
 functionality to work correctly. The keyboard functions might not work on

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -122,6 +122,7 @@ class ImageHorizonLibrary(_Keyboard,
         self.is_mac = utils.is_mac()
         self.is_linux = utils.is_linux()
         self.has_retina = utils.has_retina()
+        self.has_cv = utils.has_cv()
 
     def _get_location(self, direction, location, offset):
         x, y = location

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -128,7 +128,7 @@ class ImageHorizonLibrary(_Keyboard,
         self.is_linux = utils.is_linux()
         self.has_retina = utils.has_retina()
         self.has_cv = utils.has_cv()
-        self.confidence = self.set_confidence(confidence)
+        self.confidence = 1
 
     def _get_location(self, direction, location, offset):
         x, y = location

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -96,7 +96,8 @@ class ImageHorizonLibrary(_Keyboard,
     ROBOT_LIBRARY_VERSION = VERSION
 
     def __init__(self, reference_folder=None, screenshot_folder=None,
-                 keyword_on_failure='ImageHorizonLibrary.Take A Screenshot'):
+                 keyword_on_failure='ImageHorizonLibrary.Take A Screenshot',
+                 confidence=1):
         '''ImageHorizonLibrary can be imported with several options.
 
         ``reference_folder`` is path to the folder where all reference images
@@ -111,6 +112,10 @@ class ImageHorizonLibrary(_Keyboard,
         ``keyword_on_failure`` is the keyword to be run, when location-related
         keywords fail. If you wish to not take screenshots, use for example
         `BuiltIn.No Operation`. Keyword must however be a valid keyword.
+
+        ``confidence`` provides a tolerance for the ``reference_image``.
+                       It can be used if python-opencv is installed and
+                       is given as number between 0 and 1. Default is 1.
         '''
 
         self.reference_folder = reference_folder
@@ -123,6 +128,7 @@ class ImageHorizonLibrary(_Keyboard,
         self.is_linux = utils.is_linux()
         self.has_retina = utils.has_retina()
         self.has_cv = utils.has_cv()
+        self.confidence = confidence
 
     def _get_location(self, direction, location, offset):
         x, y = location

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -97,7 +97,7 @@ class ImageHorizonLibrary(_Keyboard,
 
     def __init__(self, reference_folder=None, screenshot_folder=None,
                  keyword_on_failure='ImageHorizonLibrary.Take A Screenshot',
-                 confidence=1):
+                 confidence=None):
         '''ImageHorizonLibrary can be imported with several options.
 
         ``reference_folder`` is path to the folder where all reference images
@@ -115,7 +115,8 @@ class ImageHorizonLibrary(_Keyboard,
 
         ``confidence`` provides a tolerance for the ``reference_image``.
                        It can be used if python-opencv is installed and
-                       is given as number between 0 and 1. Default is 1.
+                       is given as number between 0 and 1. Not used
+                       by default.
         '''
 
         self.reference_folder = reference_folder
@@ -128,7 +129,7 @@ class ImageHorizonLibrary(_Keyboard,
         self.is_linux = utils.is_linux()
         self.has_retina = utils.has_retina()
         self.has_cv = utils.has_cv()
-        self.confidence = 1
+        self.confidence = confidence
 
     def _get_location(self, direction, location, offset):
         x, y = location
@@ -243,11 +244,20 @@ class ImageHorizonLibrary(_Keyboard,
     def set_confidence(self, new_confidence):
         '''Sets the confidence level for finding images
         Applicable if opencv (python-opencv) is installed.
+        Allows for setting the value to None if you don't want
+        to use it or a value between 0 and 1 inclusive.
         '''
-        new_confidence = float(new_confidence)
-        if not 1 >= new_confidence >= 0:
-            LOGGER.warn('Unable to set confidence to {}. Value '
-                        'must be between 0 and 1, inclusive.'
-                        .format(new_confidence))
+        if new_confidence is not None:
+            try:
+                new_confidence = float(new_confidence)
+                if not 1 >= new_confidence >= 0:
+                    LOGGER.warn('Unable to set confidence to {}. Value '
+                                'must be between 0 and 1, inclusive.'
+                                .format(new_confidence))
+                else:
+                    self.confidence = new_confidence
+            except TypeError as err:
+                LOGGER.warn("Can't set confidence to {}".format(new_confidence))
         else:
-            self.confidence = new_confidence
+            self.confidence = None
+

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -128,7 +128,7 @@ class ImageHorizonLibrary(_Keyboard,
         self.is_linux = utils.is_linux()
         self.has_retina = utils.has_retina()
         self.has_cv = utils.has_cv()
-        self.confidence = confidence
+        self.confidence = self.set_confidence(confidence)
 
     def _get_location(self, direction, location, offset):
         x, y = location
@@ -244,4 +244,10 @@ class ImageHorizonLibrary(_Keyboard,
         '''Sets the confidence level for finding images
         Applicable if opencv (python-opencv) is installed.
         '''
-        self.confidence = new_confidence
+        new_confidence = float(new_confidence)
+        if not 1 >= new_confidence >= 0:
+            LOGGER.warn('Unable to set confidence to {}. Value '
+                        'must be between 0 and 1, inclusive.'
+                        .format(new_confidence))
+        else:
+            self.confidence = new_confidence

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -239,3 +239,9 @@ class ImageHorizonLibrary(_Keyboard,
         See `library importing` for more specific information.
         '''
         self.screenshot_folder = screenshot_folder_path
+
+    def set_confidence(self, new_confidence):
+        '''Sets the confidence level for finding images
+        Applicable if opencv (python-opencv) is installed.
+        '''
+        self.confidence = new_confidence

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -177,8 +177,8 @@ class _RecognizeImages(object):
                                                      confidence=self.confidence)
                     else:
                         if self.confidence:
-                            LOGGER.warning("Can't set confidence because you don't "
-                                           "have python-opencv installed.")
+                            LOGGER.warn("Can't set confidence because you don't "
+                                        "have OpenCV (python-opencv) installed.")
                         location = ag.locateOnScreen(ref_image)
                 except ImageNotFoundException as ex:
                     LOGGER.info(ex)

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -176,6 +176,9 @@ class _RecognizeImages(object):
                         location = ag.locateOnScreen(ref_image,
                                                      confidence=self.confidence)
                     else:
+                        if self.confidence:
+                            LOGGER.warning("Can't set confidence because you don't "
+                                           "have python-opencv installed.")
                         location = ag.locateOnScreen(ref_image)
                 except ImageNotFoundException as ex:
                     LOGGER.info(ex)

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -172,7 +172,7 @@ class _RecognizeImages(object):
             location = None
             with self._suppress_keyword_on_failure():
                 try:
-                    if self.has_cv:
+                    if self.has_cv and self.confidence:
                         location = ag.locateOnScreen(ref_image,
                                                      confidence=self.confidence)
                     else:

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -143,7 +143,7 @@ class _RecognizeImages(object):
         yield None
         self.keyword_on_failure = keyword
 
-    def _locate(self, reference_image, log_it=True, confidence=1):
+    def _locate(self, reference_image, log_it=True):
         is_dir = False
         try:
             if isdir(self.__normalize(reference_image)):
@@ -168,13 +168,13 @@ class _RecognizeImages(object):
                                             self.__normalize(reference_image))
                 reference_images.append(path_join(reference_image, f))
 
-        def try_locate(ref_image, confidence=1):
+        def try_locate(ref_image):
             location = None
             with self._suppress_keyword_on_failure():
                 try:
                     if self.has_cv:
                         location = ag.locateOnScreen(ref_image,
-                                                     confidence=confidence)
+                                                     confidence=self.confidence)
                     else:
                         location = ag.locateOnScreen(ref_image)
                 except ImageNotFoundException as ex:
@@ -184,7 +184,7 @@ class _RecognizeImages(object):
 
         location = None
         for ref_image in reference_images:
-            location = try_locate(ref_image, confidence)
+            location = try_locate(ref_image)
             if location != None:
                 break
 
@@ -204,37 +204,28 @@ class _RecognizeImages(object):
             y = y / 2
         return (x, y)
 
-    def does_exist(self, reference_image, confidence=1):
+    def does_exist(self, reference_image):
         '''Returns ``True`` if reference image was found on screen or
         ``False`` otherwise. Never fails.
-
-        ``confidence`` provides a tolerance for the ``reference_image``.
-                It can be used if python-opencv is installed and
-                is given as number between 0 and 1. Default is 1.
 
         See `Reference image names` for documentation for ``reference_image``.
         '''
         with self._suppress_keyword_on_failure():
             try:
-                return bool(self._locate(reference_image, log_it=False,
-                                         confidence=confidence))
+                return bool(self._locate(reference_image, log_it=False))
             except ImageNotFoundException:
                 return False
 
-    def locate(self, reference_image, confidence=1):
+    def locate(self, reference_image):
         '''Locate image on screen.
 
         Fails if image is not found on screen.
 
-        ``confidence`` provides a tolerance for the ``reference_image``.
-                       It can be used if python-opencv is installed and
-                       is given as number between 0 and 1. Default is 1.
-
         Returns Python tuple ``(x, y)`` of the coordinates.
         '''
-        return self._locate(reference_image, confidence)
+        return self._locate(reference_image)
 
-    def wait_for(self, reference_image, timeout=10, confidence=1):
+    def wait_for(self, reference_image, timeout=10):
         '''Tries to locate given image from the screen for given time.
 
         Fail if the image is not found on the screen after ``timeout`` has
@@ -244,10 +235,6 @@ class _RecognizeImages(object):
 
         ``timeout`` is given in seconds.
 
-        ``confidence`` provides a tolerance for the ``reference_image``.
-                       It can be used if python-opencv is installed and
-                       is given as number between 0 and 1. Default is 1.
-
         Returns Python tuple ``(x, y)`` of the coordinates.
         '''
         stop_time = time() + int(timeout)
@@ -255,8 +242,7 @@ class _RecognizeImages(object):
         with self._suppress_keyword_on_failure():
             while time() < stop_time:
                 try:
-                    location = self._locate(reference_image, log_it=False,
-                                            confidence=confidence)
+                    location = self._locate(reference_image, log_it=False)
                     break
                 except ImageNotFoundException:
                     pass

--- a/src/ImageHorizonLibrary/utils.py
+++ b/src/ImageHorizonLibrary/utils.py
@@ -28,3 +28,11 @@ def has_retina():
         return_code = call("system_profiler SPDisplaysDataType | grep 'Retina'", shell=True)
         return not return_code
     return 0
+
+def has_cv():
+    has_cv = True
+    try:
+        import cv2
+    except ModuleNotFoundError as err:
+        has_cv = False
+    return has_cv

--- a/tests/utest/test_main_class.py
+++ b/tests/utest/test_main_class.py
@@ -81,3 +81,21 @@ class TestMainClass(TestCase):
         self.assertEqual(self.lib.screenshot_folder, None)
         self.lib.set_screenshot_folder('/test/path')
         self.assertEqual(self.lib.screenshot_folder, '/test/path')
+
+    def test_set_confidence(self):
+        self.asserEqual(self.lib.confidence, 1)
+
+        self.lib.set_confidence(0)
+        self.assertEqual(self.lib.confidence, 0)
+
+        self.lib.set_confidence(0.5)
+        self.assertEqual(self.lib.confidence, 0.5)
+
+        self.lib.set_confidence(-1)
+        self.assertEqual(self.lib.confidence, 0.5)
+
+        self.lib.set_confidence(2)
+        self.assertEqual(self.lib.confidence, 0.5)
+
+        self.lib.set_confidence(1)
+        self.assertEqual(self.lib.confidence, 1)

--- a/tests/utest/test_main_class.py
+++ b/tests/utest/test_main_class.py
@@ -83,7 +83,7 @@ class TestMainClass(TestCase):
         self.assertEqual(self.lib.screenshot_folder, '/test/path')
 
     def test_set_confidence(self):
-        self.asserEqual(self.lib.confidence, 1)
+        self.assertEqual(self.lib.confidence, 1)
 
         self.lib.set_confidence(0)
         self.assertEqual(self.lib.confidence, 0)

--- a/tests/utest/test_main_class.py
+++ b/tests/utest/test_main_class.py
@@ -83,7 +83,7 @@ class TestMainClass(TestCase):
         self.assertEqual(self.lib.screenshot_folder, '/test/path')
 
     def test_set_confidence(self):
-        self.assertEqual(self.lib.confidence, 1)
+        self.assertEqual(self.lib.confidence, None)
 
         self.lib.set_confidence(0)
         self.assertEqual(self.lib.confidence, 0)
@@ -99,3 +99,6 @@ class TestMainClass(TestCase):
 
         self.lib.set_confidence(1)
         self.assertEqual(self.lib.confidence, 1)
+
+        self.lib.set_confidence(None)
+        self.assertEqual(self.lib.confidence, None)

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -22,6 +22,15 @@ class TestRecognizeImages(TestCase):
         self.mock.reset_mock()
         self.patcher.stop()
 
+    def test_find_with_confidence(self):
+        self.lib.reference_folder = path_join(CURDIR, 'symbolic_link')
+        self.lib.set_confidence(0.5)
+        self.lib.has_cv = True
+        self.lib.locate('mY_PiCtURe')
+        expected_path = path_join(CURDIR, 'symbolic_link', 'my_picture.png')
+        self.mock.locateOnScreen.assert_called_once_with(expected_path, confidence=0.5)
+        self.mock.reset_mock()
+
     def test_click_image(self):
         with patch(self.locate, return_value=(0, 0)):
             self.lib.click_image('my_picture')

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -31,6 +31,15 @@ class TestRecognizeImages(TestCase):
         self.mock.locateOnScreen.assert_called_once_with(expected_path, confidence=0.5)
         self.mock.reset_mock()
 
+    def test_find_with_confidence_no_opencv(self):
+        self.lib.reference_folder = path_join(CURDIR, 'symbolic_link')
+        self.lib.set_confidence(0.5)
+        self.lib.has_cv = False
+        self.lib.locate('mY_PiCtURe')
+        expected_path = path_join(CURDIR, 'symbolic_link', 'my_picture.png')
+        self.mock.locateOnScreen.assert_called_once_with(expected_path)
+        self.mock.reset_mock()
+
     def test_click_image(self):
         with patch(self.locate, return_value=(0, 0)):
             self.lib.click_image('my_picture')

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -8,14 +8,6 @@ from mock import call, MagicMock, patch
 CURDIR = abspath(dirname(__file__))
 TESTIMG_DIR = path_join(CURDIR, 'reference_images')
 
-def has_cv():
-    has_cv = True
-    try:
-        import cv2
-    except ModuleNotFoundError as err:
-        has_cv = False
-    return has_cv
-
 class TestRecognizeImages(TestCase):
     def setUp(self):
         self.mock = MagicMock()
@@ -25,7 +17,6 @@ class TestRecognizeImages(TestCase):
         self.lib = ImageHorizonLibrary(reference_folder=TESTIMG_DIR)
         self.locate = 'ImageHorizonLibrary.ImageHorizonLibrary.locate'
         self._locate = 'ImageHorizonLibrary.ImageHorizonLibrary._locate'
-        self.lib.has_cv = has_cv()
 
     def tearDown(self):
         self.mock.reset_mock()
@@ -106,10 +97,7 @@ class TestRecognizeImages(TestCase):
     def _verify_path_works(self, image_name, expected):
         self.lib.locate(image_name)
         expected_path = path_join(TESTIMG_DIR, expected)
-        if self.lib.has_cv:
-            self.mock.locateOnScreen.assert_called_once_with(expected_path, confidence=1)
-        else:
-            self.mock.locateOnScreen.assert_called_once_with(expected_path)
+        self.mock.locateOnScreen.assert_called_once_with(expected_path)
         self.mock.reset_mock()
 
     def test_locate(self):
@@ -137,20 +125,14 @@ class TestRecognizeImages(TestCase):
         self.lib.reference_folder = path_join(CURDIR, 'symbolic_link')
         self.lib.locate('mY_PiCtURe')
         expected_path = path_join(CURDIR, 'symbolic_link', 'my_picture.png')
-        if self.lib.has_cv:
-            self.mock.locateOnScreen.assert_called_once_with(expected_path, confidence=1)
-        else:
-            self.mock.locateOnScreen.assert_called_once_with(expected_path)
+        self.mock.locateOnScreen.assert_called_once_with(expected_path)
         self.mock.reset_mock()
 
         self.lib.reference_folder = path_join(CURDIR, 'rëförence_imägës')
         self.lib.locate('mŸ PäKSÖR')
         expected_path = path_join(CURDIR, 'rëförence_imägës',
                                   'mÿ_päksör.png')
-        if self.lib.has_cv:
-            self.mock.locateOnScreen.assert_called_once_with(expected_path, confidence=1)
-        else:
-            self.mock.locateOnScreen.assert_called_once_with(expected_path)
+        self.mock.locateOnScreen.assert_called_once_with(expected_path)
         self.mock.reset_mock()
 
     def test_locate_with_invalid_reference_folder(self):


### PR DESCRIPTION
Adds in a `Set Confidence` keyword. This confidence level is used internally when the library locates images on screen. Only applies when OpenCV is installed and can be turned off.