### PR TITLE
Will now detect the screen scaling ratio and adjust

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -12,6 +12,11 @@ from ..errors import ReferenceFolderException
 
 class _RecognizeImages(object):
 
+    pixel_ratio = 0.0
+
+    def __get_pixel_ratio(self):
+        self.pixel_ratio = ag.screenshot().size[0]/ag.size().width
+
     def __normalize(self, path):
         if (not self.reference_folder or
                 not isinstance(self.reference_folder, str) or
@@ -203,9 +208,11 @@ class _RecognizeImages(object):
         center_point = ag.center(location)
         x = center_point.x
         y = center_point.y
-        if self.has_retina:
-            x = x / 2
-            y = y / 2
+        if self.pixel_ratio == 0.0:
+            self.__get_pixel_ratio()
+        if self.pixel_ratio>1:
+            x = x / self.pixel_ratio
+            y = y / self.pixel_ratio
         return (x, y)
 
     def does_exist(self, reference_image):


### PR DESCRIPTION
My proposed fix for Issue #62

This update will now detect the screen scaling ratio and adjust accordingly. I tested it using "tests/atest/calculator.robot" on a mac with a Retina display running OSX 12.0.1 I don't have a windows machine to test on, but based on comments in [pyautogui issue #589](https://github.com/asweigart/pyautogui/issues/589) this should work for the various windows scaling ratios.
This replaces the self.has_retina which wasn't working as it was returning false on my machine even though it does indeed have a retina display.
__get_pixel_ratio should only get called the first time _locate is called, that was my experience in testing, though perhaps it should be called every time as windows users could potentially change their display scaling during the test. Also I don't know of an OS that supports it now but I guess it's possible in the future an OS may have a scaling factor less than 100% and this change won't support that either.
