### PR TITLE
Fix for issue #60

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -241,10 +241,10 @@ class _RecognizeImages(object):
 
         Returns Python tuple ``(x, y)`` of the coordinates.
         '''
-        stop_time = time() + int(timeout)
+        stop_time = int(time()) + int(timeout)
         location = None
         with self._suppress_keyword_on_failure():
-            while time() < stop_time:
+            while int(time()) <= stop_time:
                 try:
                     location = self._locate(reference_image, log_it=False)
                     break


### PR DESCRIPTION
Fix for issue #60

This fix ensures even if timeout is set to 0 (zero) locate is called at least once.

Screen shots of before and after tests:

|before|after|
|---|---|
|<img width="1082" alt="Screen Shot 2022-02-27 at 9 28 53 am" src="https://user-images.githubusercontent.com/15232871/155862950-b113b538-b52e-45ea-8756-2684f0ece10a.png">|<img width="1088" alt="Screen Shot 2022-02-27 at 9 56 42 am" src="https://user-images.githubusercontent.com/15232871/155862955-208274d0-2bb6-4433-9a83-277162b27992.png">|

